### PR TITLE
Update regionalBus translation.

### DIFF
--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -48,7 +48,7 @@
   "subway": "Metroo",
   "train": "Rong",
   "ferry": "Laev",
-  "regionalBus": "Piirkondlik buss",
+  "regionalBus": "Maakonnabuss",
   "commercialBus": "Kommertsbuss",
   "openTutorial": "Ava õpetus",
   "tMainScreen": "Põhiekraan",


### PR DESCRIPTION
Referenced from Peatus and Tallinn Transport websites. There this type of bus lines named as well as "maakonnaliinid" or "county lines" on English. 